### PR TITLE
Updated scopes required by the Tapkey Management API

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,11 @@ You may want to use `venv`.
 
 ## Requirements
 
-You need a Tapkey API client (Authorization Code Flow).
+You need a Tapkey Management API client (Authorization Code Flow) with the following permissions:
+
+- Core Entities: `ReadOnly`
+- Logs: `ReadOnly`
+- Owners: `ReadOnly`
 
 The following environment variables are required:
 

--- a/application.py
+++ b/application.py
@@ -48,7 +48,7 @@ oauth.register('tapkey',
                authorize_url=os.environ.get('TAPKEY_AUTHORIZATION_ENDPOINT'),
                api_base_url=f"{os.environ.get('TAPKEY_BASE_URI')}/api/v1/",
                client_kwargs={
-                   'scope': 'manage:contacts manage:grants offline_access read:logs read:grants',
+                   'scope': 'read:owneraccounts read:core:entities read:logs offline_access',
                },
                fetch_token=fetch_tapkey_token,
                )


### PR DESCRIPTION
Updated the application to use the scopes required by the Tapkey Management API. Also changed the `readme.md` to instruct users on which scopes they should request while creating their apps via our "self-service" page.