### PR TITLE
Fix redirect URI scheme 

### DIFF
--- a/application.py
+++ b/application.py
@@ -58,7 +58,11 @@ def status():
 
 @app.route('/tapkey')
 def login():
-    redirect_uri = url_for('authorize', _external=True)
+    # Force https redirects when behind a proxy (required on Azure only)
+    if 'APPINSIGHTS_INSTRUMENTATIONKEY' in os.environ:  # set on Azure
+        redirect_uri = url_for('authorize', _external=True, _scheme='https')
+    else:
+        redirect_uri = url_for('authorize', _external=True)
     return oauth.tapkey.authorize_redirect(redirect_uri)
 
 
@@ -66,11 +70,7 @@ def login():
 def authorize():
     token = oauth.tapkey.authorize_access_token()
     session['auth'] = token
-    # Force https redirects when behind a proxy (required on Azure only)
-    if 'WEBSITE_SITE_NAME' in os.environ:  # set on Azure
-        return redirect(url_for('owner_account_chooser', _scheme='https'))
-    else:
-        return redirect(url_for('owner_account_chooser'))
+    return redirect(url_for('owner_account_chooser'))
 
 
 @app.route('/export')

--- a/application.py
+++ b/application.py
@@ -27,7 +27,7 @@ if 'TAPKEY_BASE_URI' not in os.environ:
 app.secret_key = bytearray(os.environ.get('APP_SECRET_KEY'), encoding="utf-8")
 
 # Apply fix for https redirects behind a proxy (required for Azure only)
-app.wsgi_app = ProxyFix(app.wsgi_app)
+app.wsgi_app = ProxyFix(app.wsgi_app, x_for=1, x_host=1)
 
 # Application Insights (required for Azure only)
 if 'APPINSIGHTS_INSTRUMENTATIONKEY' in os.environ:

--- a/application.py
+++ b/application.py
@@ -1,7 +1,6 @@
 import datetime
 from flask import abort, Flask, make_response, url_for, redirect, render_template, request, Response, session
 from authlib.flask.client import OAuth
-from werkzeug.middleware.proxy_fix import ProxyFix
 from applicationinsights.flask.ext import AppInsights
 import os
 import io
@@ -27,7 +26,8 @@ if 'TAPKEY_BASE_URI' not in os.environ:
 app.secret_key = bytearray(os.environ.get('APP_SECRET_KEY'), encoding="utf-8")
 
 # Apply fix for https redirects behind a proxy (required for Azure only)
-app.wsgi_app = ProxyFix(app.wsgi_app, x_for=1, x_host=1)
+if 'WEBSITE_SITE_NAME' in os.environ:
+    app.config['PREFERRED_URL_SCHEME'] = 'https'
 
 # Application Insights (required for Azure only)
 if 'APPINSIGHTS_INSTRUMENTATIONKEY' in os.environ:


### PR DESCRIPTION
When running on Azure, due to the reverse proxy in place in app services, the URI builder resolves to `http`. I hard-coded it to `https` when running in an Azure environment.

Will squash merge, so don't worry about individual commits or commit messages.